### PR TITLE
Support for `<col>` elements in the XML-Dom with according `align`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ configureAsXhtmlTableElements(sxModule, {
 	// True if a tbody element should be used.
 	useTbody: true,
 
+	// False if the borders attribute should not be used
+	useBorder: true,
+
+	// True if the table should include <col> elements by default
+	shouldCreateColumnSpecificationNodes: false,
+
 	// The namespace uri for the table element and its descendant elements (optional)
 	table: {
 		namespaceURI: 'http://some-uri.com/'

--- a/src/configureAsXhtmlTableElements.js
+++ b/src/configureAsXhtmlTableElements.js
@@ -25,6 +25,7 @@ define([
 	 * @param  {boolean} [options.useThead]                Set to true if thead should be used
 	 * @param  {boolean} [options.useTbody]                Set to true if tbody should be used
 	 * @param  {boolean} [options.useBorders=true]         Set to false if the borders attribute should not be used
+	 * @param  {boolean} [options.shouldCreateColumnSpecificationNodes=false] Set to true if the table should include <col> elements by default
 	 * @param  {Object}  [options.table]                   Options for the table element
 	 * @param  {XPathTest}  [options.table.tableFilterSelector]  An optional additional selector for the table which will be used to refine whether a table element should be considered as an xhtml table
 	 * @param  {string}  [options.table.namespaceURI='']   The namespace URI for this table

--- a/src/operations-column-alignment.json
+++ b/src/operations-column-alignment.json
@@ -8,15 +8,9 @@
 				}
 			},
 			{
-				"type": "transform/setContextNodeIdToFirstMatchingNodeFromContextNode",
-				"data": {
-					"xPathQuery": "let $current := . return $current/ancestor::table[1]/col[position() = fonto:get-column-index($current) + 1]"
-				}
-			},
-			{
 				"type": "operation/set-attributes",
 				"data": {
-					"contextNodeId": "let $current :=  x__$data('contextNode') return $current/ancestor::table[1]/col[position() = fonto:get-column-index($current) + 1]",
+                    "contextNodeId": "x__let $current := $data('contextNode') return $current/ancestor::table[1]/col[position() = fonto:get-column-index($current) + 1]",
 					"attributes": {
 						"align": "{{align}}"
 					},

--- a/src/operations-column-alignment.json
+++ b/src/operations-column-alignment.json
@@ -10,12 +10,13 @@
 			{
 				"type": "transform/setContextNodeIdToFirstMatchingNodeFromContextNode",
 				"data": {
-					"xPathQuery": "let $current := . return $current/ancestor::table[1]/col[position() = count($current/preceding-sibling::td) + 1]"
+					"xPathQuery": "let $current := . return $current/ancestor::table[1]/col[position() = fonto:get-column-index($current) + 1]"
 				}
 			},
 			{
 				"type": "operation/set-attributes",
 				"data": {
+					"contextNodeId": "let $current :=  x__$data('contextNode') return $current/ancestor::table[1]/col[position() = fonto:get-column-index($current) + 1]",
 					"attributes": {
 						"align": "{{align}}"
 					},

--- a/src/operations-column-alignment.json
+++ b/src/operations-column-alignment.json
@@ -1,0 +1,95 @@
+{
+	"_xhtml-set-column-align": {
+		"steps": [
+			{
+				"type": "transform/setContextNodeIdToSelectionAncestor",
+				"data": {
+					"selectionAncestorMatchesSomeOf": ["self::td", "self::th"]
+				}
+			},
+			{
+				"type": "transform/setContextNodeIdToFirstMatchingNodeFromContextNode",
+				"data": {
+					"xPathQuery": "let $current := . return $current/ancestor::table[1]/col[position() = count($current/preceding-sibling::td) + 1]"
+				}
+			},
+			{
+				"type": "operation/set-attributes",
+				"data": {
+					"attributes": {
+						"align": "{{align}}"
+					},
+					"disabledWhenUnchanged": true
+				}
+			}
+		]
+	},
+	"xhtml-set-col-horizontal-alignment-left": {
+		"__documentation": {
+			"fontosdk": true,
+			"category": "add-on/fontoxml-table-flow-xhtml"
+		},
+		"label": "t__Align left",
+		"description": "t__Align the content of the current column to its left.",
+		"icon": "align-left",
+		"steps": [
+			{
+				"type": "operation/_xhtml-set-column-align",
+				"data": {
+					"align": "left"
+				}
+			}
+		]
+	},
+	"xhtml-set-col-horizontal-alignment-center": {
+		"__documentation": {
+			"fontosdk": true,
+			"category": "add-on/fontoxml-table-flow-xhtml"
+		},
+		"label": "t__Align center",
+		"description": "t__Align the content of the current column to its center.",
+		"icon": "align-center",
+		"steps": [
+			{
+				"type": "operation/_xhtml-set-column-align",
+				"data": {
+					"align": "center"
+				}
+			}
+		]
+	},
+	"xhtml-set-col-horizontal-alignment-right": {
+		"__documentation": {
+			"fontosdk": true,
+			"category": "add-on/fontoxml-table-flow-xhtml"
+		},
+		"label": "t__Align right",
+		"description": "t__Align the content of the current column to its right.",
+		"icon": "align-right",
+		"steps": [
+			{
+				"type": "operation/_xhtml-set-column-align",
+				"data": {
+					"align": "right"
+				}
+			}
+		]
+	},
+	"xhtml-set-col-horizontal-alignment-justify": {
+		"__documentation": {
+			"fontosdk": true,
+			"category": "add-on/fontoxml-table-flow-xhtml"
+		},
+		"label": "t__Justify",
+		"description": "t__Justify the content of the current col.",
+		"icon": "align-right",
+		"steps": [
+			{
+				"type": "operation/_xhtml-set-column-align",
+				"data": {
+					"align": "justify"
+				}
+			}
+		]
+	}
+}

--- a/src/table-definition/XhtmlTableDefinition.js
+++ b/src/table-definition/XhtmlTableDefinition.js
@@ -2,6 +2,7 @@ define([
 	'fontoxml-table-flow/TableDefinition',
 	'fontoxml-table-flow/createCreateCellNodeStrategy',
 	'fontoxml-table-flow/createCreateRowStrategy',
+	'fontoxml-table-flow/createCreateColumnSpecificationNodeStrategy',
 	'fontoxml-table-flow/getSpecificationValueStrategies',
 	'fontoxml-table-flow/normalizeCellNodeStrategies',
 	'fontoxml-table-flow/normalizeContainerNodeStrategies',
@@ -10,6 +11,7 @@ define([
 	TableDefinition,
 	createCreateCellNodeStrategy,
 	createCreateRowStrategy,
+	createCreateColumnSpecificationNodeStrategy,
 	getSpecificationValueStrategies,
 	normalizeCellNodeStrategies,
 	normalizeContainerNodeStrategies,
@@ -27,6 +29,7 @@ define([
 		var useTbody = !!options.useTbody;
 		var useTh = !!options.useTh;
 		var useBorders = options.useBorders !== false;
+		var shouldCreateColumnSpecificationNodes = options.shouldCreateColumnSpecificationNodes !== false;
 
 		// Warn the developer that thead is used as header-defining element. This is required when
 		// using tbody.
@@ -85,6 +88,8 @@ define([
 
 			supportsBorders: useBorders,
 
+			shouldCreateColumnSpecificationNodes: shouldCreateColumnSpecificationNodes,
+
 			// Defining node selectors
 			tablePartsNodeSelector: Object.keys(selectorParts)
 				.filter(function (selector) {
@@ -139,6 +144,7 @@ define([
 			// Creates
 			createCellNodeStrategy: createCreateCellNodeStrategy(namespaceURI, 'td'),
 			createRowStrategy: createCreateRowStrategy(namespaceURI, 'tr'),
+			createColumnSpecificationNodeStrategy: createCreateColumnSpecificationNodeStrategy(namespaceURI, 'col', './*[self::' + thead + ' or self::' + tbody + ']'),
 
 			// Specification
 			getTableSpecificationStrategies: useBorders ? [

--- a/src/table-definition/XhtmlTableDefinition.js
+++ b/src/table-definition/XhtmlTableDefinition.js
@@ -29,7 +29,7 @@ define([
 		var useTbody = !!options.useTbody;
 		var useTh = !!options.useTh;
 		var useBorders = options.useBorders !== false;
-		var shouldCreateColumnSpecificationNodes = options.shouldCreateColumnSpecificationNodes !== false;
+		var shouldCreateColumnSpecificationNodes = !!options.shouldCreateColumnSpecificationNodes;
 
 		// Warn the developer that thead is used as header-defining element. This is required when
 		// using tbody.

--- a/src/table-definition/XhtmlTableDefinition.js
+++ b/src/table-definition/XhtmlTableDefinition.js
@@ -51,7 +51,8 @@ define([
 
 		var namespaceSelector = 'Q{' + namespaceURI + '}';
 		var selectorParts = {
-			table: namespaceSelector + 'table' + (options.table && options.table.tableFilterSelector ?
+			table: namespaceSelector + 'table' + (
+				options.table && options.table.tableFilterSelector ?
 					'[' + options.table.tableFilterSelector + ']' :
 					''),
 			headerContainer: namespaceSelector + 'thead',
@@ -125,59 +126,50 @@ define([
 
 			// Normalizations
 			normalizeContainerNodeStrategies: [
-					useThead ?
-						normalizeContainerNodeStrategies.createAddHeaderContainerNodeStrategy(namespaceURI, 'thead') :
-						normalizeContainerNodeStrategies.createRemoveHeaderContainerNodeStrategy(),
-					useTbody ?
-						normalizeContainerNodeStrategies.createAddBodyContainerNodeStrategy(namespaceURI, 'tbody') :
-						normalizeContainerNodeStrategies.createRemoveBodyContainerNodeStrategy(),
-					normalizeContainerNodeStrategies.createRemoveFooterContainerNodeStrategy()
-				],
+				useThead ?
+					normalizeContainerNodeStrategies.createAddHeaderContainerNodeStrategy(namespaceURI, 'thead') :
+					normalizeContainerNodeStrategies.createRemoveHeaderContainerNodeStrategy(),
+				useTbody ?
+					normalizeContainerNodeStrategies.createAddBodyContainerNodeStrategy(namespaceURI, 'tbody') :
+					normalizeContainerNodeStrategies.createRemoveBodyContainerNodeStrategy(),
+				normalizeContainerNodeStrategies.createRemoveFooterContainerNodeStrategy()
+			],
 
 			normalizeCellNodeStrategies: [
-					useTh ?
-						normalizeCellNodeStrategies.createConvertHeaderCellNodeStrategy(namespaceURI, 'th') :
-						normalizeCellNodeStrategies.createConvertHeaderCellNodeStrategy(namespaceURI, 'td'),
-					normalizeCellNodeStrategies.createConvertFormerHeaderCellNodeStrategy(namespaceURI, 'td')
-				],
+				useTh ?
+					normalizeCellNodeStrategies.createConvertHeaderCellNodeStrategy(namespaceURI, 'th') :
+					normalizeCellNodeStrategies.createConvertHeaderCellNodeStrategy(namespaceURI, 'td'),
+				normalizeCellNodeStrategies.createConvertFormerHeaderCellNodeStrategy(namespaceURI, 'td')
+			],
 
 			// Creates
 			createCellNodeStrategy: createCreateCellNodeStrategy(namespaceURI, 'td'),
 			createRowStrategy: createCreateRowStrategy(namespaceURI, 'tr'),
-			createColumnSpecificationNodeStrategy: createCreateColumnSpecificationNodeStrategy(namespaceURI, 'col', './*[self::' + thead + ' or self::' + tbody + ']'),
+			createColumnSpecificationNodeStrategy: shouldCreateColumnSpecificationNodes ?
+				createCreateColumnSpecificationNodeStrategy(namespaceURI, 'col', './*[self::' + thead + ' or self::' + tbody + ' or self::' + tr + ']') :
+				undefined,
 
 			// Specification
 			getTableSpecificationStrategies: useBorders ? [
-					getSpecificationValueStrategies.createGetValueAsBooleanStrategy('borders', './@border = "1"')
-				] : [],
-
-			getColumnSpecificationStrategies: [
-					getSpecificationValueStrategies.createGetValueAsStringStrategy('columnWidth', '"1*"'),
-					getSpecificationValueStrategies.createGetValueAsStringStrategy('horizontalAlignment', './@align'),
-					getSpecificationValueStrategies.createGetValueAsStringStrategy('verticalAlignment', './@valign')
-				],
+				getSpecificationValueStrategies.createGetValueAsBooleanStrategy('borders', './@border = "1"')
+			] : [],
 
 			getCellSpecificationStrategies: [
-					getSpecificationValueStrategies.createGetValueAsStringStrategy('horizontalAlignment', './@align'),
-					getSpecificationValueStrategies.createGetValueAsStringStrategy('verticalAlignment', './@valign')
-				].concat(useBorders ? [
-					getSpecificationValueStrategies.createGetValueAsBooleanStrategy('columnSeparator', './ancestor::' + table + '[1]/@border = "1"'),
-					getSpecificationValueStrategies.createGetValueAsBooleanStrategy('rowSeparator', './ancestor::' + table + '[1]/@border = "1"')
-				] : []),
+				getSpecificationValueStrategies.createGetValueAsStringStrategy('horizontalAlignment', './@align'),
+				getSpecificationValueStrategies.createGetValueAsStringStrategy('verticalAlignment', './@valign')
+			].concat(useBorders ? [
+				getSpecificationValueStrategies.createGetValueAsBooleanStrategy('columnSeparator', './ancestor::' + table + '[1]/@border = "1"'),
+				getSpecificationValueStrategies.createGetValueAsBooleanStrategy('rowSeparator', './ancestor::' + table + '[1]/@border = "1"')
+			] : []),
 
 			// Set attributes
 			setTableNodeAttributeStrategies: useBorders ? [
-					setAttributeStrategies.createBooleanValueAsAttributeStrategy('border', 'borders', null, '1', '0')
-				] : [],
+				setAttributeStrategies.createBooleanValueAsAttributeStrategy('border', 'borders', null, '1', '0')
+			] : [],
 
 			setCellNodeAttributeStrategies: [
-					setAttributeStrategies.createRowSpanAsAttributeStrategy('rowspan'),
-					setAttributeStrategies.createColumnSpanAsAttributeStrategy('colspan'),
-					setAttributeStrategies.createStringValueAsAttributeStrategy('align', 'horizontalAlignment'),
-					setAttributeStrategies.createStringValueAsAttributeStrategy('valign', 'verticalAlignment')
-				],
-
-			setColumnSpecificationNodeAttributeStrategies: [
+				setAttributeStrategies.createRowSpanAsAttributeStrategy('rowspan'),
+				setAttributeStrategies.createColumnSpanAsAttributeStrategy('colspan'),
 				setAttributeStrategies.createStringValueAsAttributeStrategy('align', 'horizontalAlignment'),
 				setAttributeStrategies.createStringValueAsAttributeStrategy('valign', 'verticalAlignment')
 			]

--- a/src/table-definition/XhtmlTableDefinition.js
+++ b/src/table-definition/XhtmlTableDefinition.js
@@ -152,7 +152,9 @@ define([
 				] : [],
 
 			getColumnSpecificationStrategies: [
-					getSpecificationValueStrategies.createGetValueAsStringStrategy('columnWidth', '"1*"')
+					getSpecificationValueStrategies.createGetValueAsStringStrategy('columnWidth', '"1*"'),
+					getSpecificationValueStrategies.createGetValueAsStringStrategy('horizontalAlignment', './@align'),
+					getSpecificationValueStrategies.createGetValueAsStringStrategy('verticalAlignment', './@valign')
 				],
 
 			getCellSpecificationStrategies: [
@@ -173,7 +175,12 @@ define([
 					setAttributeStrategies.createColumnSpanAsAttributeStrategy('colspan'),
 					setAttributeStrategies.createStringValueAsAttributeStrategy('align', 'horizontalAlignment'),
 					setAttributeStrategies.createStringValueAsAttributeStrategy('valign', 'verticalAlignment')
-				]
+				],
+
+			setColumnSpecificationNodeAttributeStrategies: [
+				setAttributeStrategies.createStringValueAsAttributeStrategy('align', 'horizontalAlignment'),
+				setAttributeStrategies.createStringValueAsAttributeStrategy('valign', 'verticalAlignment')
+			]
 		};
 
 		TableDefinition.call(this, properties);

--- a/test/specs/XhtmlRoundtrip.tests.js
+++ b/test/specs/XhtmlRoundtrip.tests.js
@@ -1,6 +1,7 @@
 import blueprints from 'fontoxml-blueprints';
 import core from 'fontoxml-core';
 import jsonMLMapper from 'fontoxml-dom-utils/jsonMLMapper';
+import evaluateXPathToBoolean from 'fontoxml-selectors/evaluateXPathToBoolean';
 import * as slimdom from 'slimdom';
 
 import XhtmlTableDefinition from 'fontoxml-table-flow-xhtml/table-definition/XhtmlTableDefinition';
@@ -20,16 +21,19 @@ const Blueprint = blueprints.Blueprint;
 const CoreDocument = core.Document;
 
 const stubFormat = {
-		synthesizer: {
-			completeStructure: () => true
-		},
-		metadata: {
-			get: (_option, _node) => false
-		},
-		validator: {
-			canContain: () => true
+	synthesizer: {
+		completeStructure: (node, blueprint) => {
+			// Column nodes should be the first nodes, after a non-col, we expect no more cols.
+			return evaluateXPathToBoolean('every $node in ./* satisfies if (name($node) != "col") then $node/following-sibling::col => empty() else true()', node, blueprint);
 		}
-	};
+	},
+	metadata: {
+		get: (_option, _node) => false
+	},
+	validator: {
+		canContain: () => true
+	}
+};
 
 describe('XHTML tables: XML to XML roundtrip', () => {
 	let documentNode;
@@ -62,39 +66,45 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 	describe('Without changes', () => {
 		it('can handle a 1x1 table, changing nothing', () => {
-			const jsonIn = ['table',
-					['tr', ['td']]
-				];
+			const jsonIn = [
+				'table',
+				['tr', ['td']]
+			];
 
-			const jsonOut = ['table', { border: '0' },
-					['tr', ['td']]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				['tr', ['td']]
+			];
 
 			const options = {
-					useTh: true
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useTh: true
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can handle a 4x4 table, changing nothing', () => {
-			const jsonIn = ['table',
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonIn = [
+				'table',
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
-			const jsonOut = ['table', { border: '0' },
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
 			const options = {
-					useTh: true
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useTh: true
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
@@ -103,105 +113,117 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 	describe('Header rows', () => {
 		describe('th-based header', () => {
 			it('can handle a 4x4 table, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 2 header rows, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -209,117 +231,135 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('thead based', () => {
 			it('can handle a 4x4 table, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
+				const jsonIn = [
+					'table',
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
+				const jsonIn = [
+					'table',
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 2 header rows, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
+				const jsonIn = [
+					'table',
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -327,117 +367,135 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('th and thead based', () => {
 			it('can handle a 4x4 table, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']],
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']],
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 2 header rows, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']],
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']],
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -445,133 +503,159 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('tbody and thead based', () => {
 			it('can handle a 4x4 table, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 2 header rows, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -579,133 +663,159 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('tbody, th and thead based', () => {
 			it('can handle a 4x4 table, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']],
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']],
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 1 header row, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table with 2 header rows, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']],
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']],
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['th'], ['th'], ['th'], ['th']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['th'], ['th'], ['th'], ['th']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -713,141 +823,171 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('thead, tbody and tfoot based', () => {
 			it('can handle a 4x4 table (thead, tbody, tfoot), increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tfoot',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tfoot',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table (thead, tbody, tfoot based) with 1 header row, increasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tfoot',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tfoot',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.increaseHeaderRowCount(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table (thead, tbody, tfoot based) with 1 header row, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tfoot',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tfoot',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table (thead, tbody, tfoot based) with 2 header rows, decreasing the header row count by 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tfoot',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tfoot',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.decreaseHeaderRowCount();
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -856,166 +996,195 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 	describe('Insert row', () => {
 		it('can handle a 4x4 table (tbody), adding 1 row before index 0', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
 
-				];
+			];
 
 			const mutateGridModel = (gridModel) => gridModel.insertRow(0, false);
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 
 		it('can handle a 4x4 table (tbody), adding 1 row before index 2 (middle)', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
 
-				];
+			];
 
 			const mutateGridModel = (gridModel) => gridModel.insertRow(2, false);
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 
 		it('can handle a 4x4 table (tbody), adding 1 row after index 3 (last)', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const mutateGridModel = (gridModel) => gridModel.insertRow(3, true);
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 
 		it('can handle a 4x4 table (tbody, thead), adding 1 row before index 0', () => {
-			const jsonIn = ['table',
-					['thead',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'thead',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				],
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const mutateGridModel = (gridModel) => gridModel.insertRow(0, false);
 
-			const jsonOut = ['table', { border: '0' },
-					['thead',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'thead',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				],
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 
 		it('can handle a 4x4 table (tbody, thead), adding 1 row after index 1 (last header row)', () => {
-			const jsonIn = ['table',
-					['thead',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'thead',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				],
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const mutateGridModel = (gridModel) => gridModel.insertRow(1, true);
 
-			const jsonOut = ['table', { border: '0' },
-					['thead',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'thead',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				],
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
@@ -1024,88 +1193,103 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 	describe('Delete row', () => {
 		describe('tbody based', () => {
 			it('can handle a 4x4 table, deleting 1 row at index 0', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table, deleting 1 row at index 2 (middle)', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(2);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table, deleting 1 row at index 3 (last)', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(3);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -1113,76 +1297,85 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('row based', () => {
 			it('can handle a 4x4 table, deleting 1 row at index 0', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table, deleting 1 row at index 2 (middle)', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(2);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table, deleting 1 row at index 3 (last)', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(3);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -1190,76 +1383,85 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('th based', () => {
 			it('can handle 4x4 a table with 1 header row, deleting 1 row at index 0', () => {
-				const jsonIn = ['table',
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle 4x4 a table with 2 header rows, deleting 1 row at index 0', () => {
-				const jsonIn = ['table',
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle 4x4 a table with 2 header rows, deleting 1 row at index 1', () => {
-				const jsonIn = ['table',
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['th'], ['th'], ['th'], ['th']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['th'], ['th'], ['th'], ['th']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: false,
-						useTbody: false,
-						useTh: true
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: false,
+					useTbody: false,
+					useTh: true
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -1267,86 +1469,100 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('thead based', () => {
 			it('can handle 4x4 a table with 1 header row, deleting 1 row at index 0', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
+				const jsonIn = [
+					'table',
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle 4x4 a table with 2 header rows, deleting 1 row at index 0', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
+				const jsonIn = [
+					'table',
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle 4x4 a table with 2 header rows, deleting 1 row at index 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
+				const jsonIn = [
+					'table',
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tr', ['td'], ['td'], ['td'], ['td']],
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
 						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+					],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -1354,98 +1570,118 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('thead and tbody based', () => {
 			it('can handle 4x4 a table with 1 header row, deleting 1 row at index 0', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle 4x4 a table with 2 header rows, deleting 1 row at index 0', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle 4x4 a table with 2 header rows, deleting 1 row at index 1', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteRow(1);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -1454,9 +1690,12 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 	describe('Insert column', () => {
 		describe('tbody based', () => {
-			it('can handle a 4x4 table based, adding 1 column before index 0', () => {
-				const jsonIn = ['table',
-						['tbody',
+			describe('without colspecs', () => {
+				it('can handle a 4x4 table based, adding 1 column before index 0', () => {
+					const jsonIn = [
+						'table',
+						[
+							'tbody',
 							['tr', ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td']],
@@ -1464,10 +1703,12 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 						]
 					];
 
-				const mutateGridModel = (gridModel) => gridModel.insertColumn(0, false);
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(0, false);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
+					const jsonOut = [
+						'table', { border: '0' },
+						[
+							'tbody',
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
@@ -1475,18 +1716,97 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 						]
 					];
 
-				const options = {
+					const options = {
+						shouldCreateColumnSpecificationNodes: false,
 						useThead: true,
 						useTbody: true,
 						useTh: false
 					};
 
-				transformTable(jsonIn, jsonOut, options, mutateGridModel);
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
+
+				it('can handle a 4x4 table based, adding 1 column before index 2', () => {
+					const jsonIn = [
+						'table',
+						[
+							'tbody',
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']]
+						]
+					];
+
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(2, false);
+
+					const jsonOut = [
+						'table', { border: '0' },
+						[
+							'tbody',
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+						]
+					];
+
+					const options = {
+						shouldCreateColumnSpecificationNodes: false,
+						useThead: true,
+						useTbody: true,
+						useTh: false
+					};
+
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
+
+				it('can transform a 4x4 table based, adding 1 column after index 3', () => {
+					const jsonIn = [
+						'table',
+						[
+							'tbody',
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']]
+						]
+					];
+
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(3, true);
+
+					const jsonOut = [
+						'table', { border: '0' },
+						[
+							'tbody',
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+						]
+					];
+
+					const options = {
+						shouldCreateColumnSpecificationNodes: false,
+						useThead: true,
+						useTbody: true,
+						useTh: false
+					};
+
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
 			});
 
-			it('can handle a 4x4 table based, adding 1 column before index 2', () => {
-				const jsonIn = ['table',
-						['tbody',
+			describe('with colspecs', () => {
+				it('can handle a 4x4 table based, adding 1 column before index 0', () => {
+					const jsonIn = [
+						'table',
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						[
+							'tbody',
 							['tr', ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td']],
@@ -1494,10 +1814,17 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 						]
 					];
 
-				const mutateGridModel = (gridModel) => gridModel.insertColumn(2, false);
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(0, false);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
+					const jsonOut = [
+						'table', { border: '0' },
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						[
+							'tbody',
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
@@ -1505,18 +1832,25 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 						]
 					];
 
-				const options = {
+					const options = {
+						shouldCreateColumnSpecificationNodes: true,
 						useThead: true,
 						useTbody: true,
 						useTh: false
 					};
 
-				transformTable(jsonIn, jsonOut, options, mutateGridModel);
-			});
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
 
-			it('can transform a 4x4 table based, adding 1 column after index 3', () => {
-				const jsonIn = ['table',
-						['tbody',
+				it('can handle a 4x4 table based, adding 1 column before index 2', () => {
+					const jsonIn = [
+						'table',
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						[
+							'tbody',
 							['tr', ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td']],
@@ -1524,10 +1858,17 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 						]
 					];
 
-				const mutateGridModel = (gridModel) => gridModel.insertColumn(3, true);
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(2, false);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
+					const jsonOut = [
+						'table', { border: '0' },
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						[
+							'tbody',
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
@@ -1535,195 +1876,389 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 						]
 					];
 
-				const options = {
+					const options = {
+						shouldCreateColumnSpecificationNodes: true,
 						useThead: true,
 						useTbody: true,
 						useTh: false
 					};
 
-				transformTable(jsonIn, jsonOut, options, mutateGridModel);
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
+
+				it('can transform a 4x4 table based, adding 1 column after index 3', () => {
+					const jsonIn = [
+						'table',
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						[
+							'tbody',
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td']]
+						]
+					];
+
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(3, true);
+
+					const jsonOut = [
+						'table', { border: '0' },
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						[
+							'tbody',
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+						]
+					];
+
+					const options = {
+						shouldCreateColumnSpecificationNodes: true,
+						useThead: true,
+						useTbody: true,
+						useTh: false
+					};
+
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
 			});
 		});
 
 		describe('row based', () => {
-			it('can handle a 4x4 table based, adding 1 column before index 0', () => {
-				const jsonIn = ['table',
+			describe('without colspecs', () => {
+				it('can handle a 4x4 table based, adding 1 column before index 0', () => {
+					const jsonIn = [
+						'table',
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']]
 					];
 
-				const mutateGridModel = (gridModel) => gridModel.insertColumn(0, false);
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(0, false);
 
-				const jsonOut = ['table', { border: '0' },
+					const jsonOut = [
+						'table', { border: '0' },
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
 					];
 
-				const options = {
+					const options = {
+						shouldCreateColumnSpecificationNodes: false,
 						useThead: true,
 						useTbody: false,
 						useTh: false
 					};
 
-				transformTable(jsonIn, jsonOut, options, mutateGridModel);
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
+
+				it('can handle a 4x4 table based, adding 1 column before index 2', () => {
+					const jsonIn = [
+						'table',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					];
+
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(2, false);
+
+					const jsonOut = [
+						'table', { border: '0' },
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					];
+
+					const options = {
+						shouldCreateColumnSpecificationNodes: false,
+						useThead: true,
+						useTbody: false,
+						useTh: false
+					};
+
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
+
+				it('can transform a 4x4 table based, adding 1 column after index 3', () => {
+					const jsonIn = [
+						'table',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					];
+
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(3, true);
+
+					const jsonOut = [
+						'table', { border: '0' },
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					];
+
+					const options = {
+						shouldCreateColumnSpecificationNodes: false,
+						useThead: true,
+						useTbody: false,
+						useTh: false
+					};
+
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
 			});
 
-			it('can handle a 4x4 table based, adding 1 column before index 2', () => {
-				const jsonIn = ['table',
+			describe('with colspecs', () => {
+				it('can handle a 4x4 table based, adding 1 column before index 0', () => {
+					const jsonIn = [
+						'table',
+						['col'],
+						['col'],
+						['col'],
+						['col'],
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']]
 					];
 
-				const mutateGridModel = (gridModel) => gridModel.insertColumn(2, false);
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(0, false);
 
-				const jsonOut = ['table', { border: '0' },
+					const jsonOut = [
+						'table', { border: '0' },
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						['col'],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
 					];
 
-				const options = {
+					const options = {
+						shouldCreateColumnSpecificationNodes: true,
 						useThead: true,
 						useTbody: false,
 						useTh: false
 					};
 
-				transformTable(jsonIn, jsonOut, options, mutateGridModel);
-			});
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
 
-			it('can transform a 4x4 table based, adding 1 column after index 3', () => {
-				const jsonIn = ['table',
+				it('can handle a 4x4 table based, adding 1 column before index 2', () => {
+					const jsonIn = [
+						'table',
+						['col'],
+						['col'],
+						['col'],
+						['col'],
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td']]
 					];
 
-				const mutateGridModel = (gridModel) => gridModel.insertColumn(3, true);
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(2, false);
 
-				const jsonOut = ['table', { border: '0' },
+					const jsonOut = [
+						'table', { border: '0' },
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						['col'],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
 						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
 					];
 
-				const options = {
+					const options = {
+						shouldCreateColumnSpecificationNodes: true,
 						useThead: true,
 						useTbody: false,
 						useTh: false
 					};
 
-				transformTable(jsonIn, jsonOut, options, mutateGridModel);
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
+
+				it('can transform a 4x4 table based, adding 1 column after index 3', () => {
+					const jsonIn = [
+						'table',
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					];
+
+					const mutateGridModel = (gridModel) => gridModel.insertColumn(3, true);
+
+					const jsonOut = [
+						'table', { border: '0' },
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						['col'],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					];
+
+					const options = {
+						shouldCreateColumnSpecificationNodes: true,
+						useThead: true,
+						useTbody: false,
+						useTh: false
+					};
+
+					transformTable(jsonIn, jsonOut, options, mutateGridModel);
+				});
 			});
 		});
 
 		describe('thead and tbody based', () => {
 			it('can handle a 4x4 table based with 1 header row, adding 1 column before index 0', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.insertColumn(0, false);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table based with 1 header row, adding 1 column before index 2', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.insertColumn(2, false);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can transform a 4x4 table based with 1 header row, adding 1 column after index 3', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.insertColumn(3, true);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -1733,91 +2268,106 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 	describe('Delete column', () => {
 		describe('tbody based', () => {
 			it('can handle a 4x4 table based, deleting 1 column at index 0', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteColumn(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table based, deleting 1 column at index 2', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteColumn(2);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can transform a 4x4 table based, deleting 1 column at index 3', () => {
-				const jsonIn = ['table',
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteColumn(3);
 
-				const jsonOut = ['table', { border: '0' },
-						['tbody',
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -1825,79 +2375,88 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('row based', () => {
 			it('can handle a 4x4 table based, deleting 1 column at index 0', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteColumn(0);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table based, deleting 1 column at index 2', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteColumn(2);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can transform a 4x4 table based, deleting 1 column at index 3', () => {
-				const jsonIn = ['table',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					];
+				const jsonIn = [
+					'table',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.deleteColumn(3);
 
-				const jsonOut = ['table', { border: '0' },
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: false,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: false,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -1905,103 +2464,124 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 		describe('thead and tbody based', () => {
 			it('can handle a 4x4 table based with 1 header row, adding 1 column before index 0', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.insertColumn(0, false);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can handle a 4x4 table based with 1 header row, adding 1 column before index 2', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.insertColumn(2, false);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
 
 			it('can transform a 4x4 table based with 1 header row, adding 1 column after index 3', () => {
-				const jsonIn = ['table',
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonIn = [
+					'table',
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const mutateGridModel = (gridModel) => gridModel.insertColumn(3, true);
 
-				const jsonOut = ['table', { border: '0' },
-						['thead',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						],
-						['tbody',
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
-							['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
-						]
-					];
+				const jsonOut = [
+					'table', { border: '0' },
+					[
+						'thead',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					],
+					[
+						'tbody',
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']],
+						['tr', ['td'], ['td'], ['td'], ['td'], ['td']]
+					]
+				];
 
 				const options = {
-						useThead: true,
-						useTbody: true,
-						useTh: false
-					};
+					shouldCreateColumnSpecificationNodes: false,
+					useThead: true,
+					useTbody: true,
+					useTh: false
+				};
 
 				transformTable(jsonIn, jsonOut, options, mutateGridModel);
 			});
@@ -2010,117 +2590,133 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 	describe('Merging cells', () => {
 		it('can handle a 3x3 table, merging a cell with the cell above', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
-			const mutateGridModel = (gridModel) =>
-				mergeCellWithCellAbove(gridModel, gridModel.getCellAtCoordinates(1, 1), blueprint);
+			const mutateGridModel = (gridModel) => mergeCellWithCellAbove(gridModel, gridModel.getCellAtCoordinates(1, 1), blueprint);
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td', { rowspan: '2' }], ['td']],
-						['tr', ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td', { rowspan: '2' }], ['td']],
+					['tr', ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 
 		it('can handle a 3x3 table, merging a cell with the cell to the right', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
-			const mutateGridModel = (gridModel) =>
-				mergeCellWithCellToTheRight(gridModel, gridModel.getCellAtCoordinates(1, 1), blueprint);
+			const mutateGridModel = (gridModel) => mergeCellWithCellToTheRight(gridModel, gridModel.getCellAtCoordinates(1, 1), blueprint);
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td', { colspan: '2' }]],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td', { colspan: '2' }]],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 
 		it('can handle a 3x3 table, merging a cell with the cell below', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
-			const mutateGridModel = (gridModel) =>
-				mergeCellWithCellBelow(gridModel, gridModel.getCellAtCoordinates(1, 1), blueprint);
+			const mutateGridModel = (gridModel) => mergeCellWithCellBelow(gridModel, gridModel.getCellAtCoordinates(1, 1), blueprint);
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td', { rowspan: '2' }], ['td']],
-						['tr', ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td', { rowspan: '2' }], ['td']],
+					['tr', ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 
 		it('can handle a 3x3 table, merging a cell with a cell to the left', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
-			const mutateGridModel = (gridModel) =>
-				mergeCellWithCellToTheLeft(gridModel, gridModel.getCellAtCoordinates(1, 1), blueprint);
+			const mutateGridModel = (gridModel) => mergeCellWithCellToTheLeft(gridModel, gridModel.getCellAtCoordinates(1, 1), blueprint);
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td', { colspan: '2' }], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td', { colspan: '2' }], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
@@ -2128,302 +2724,382 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 
 	describe('Split cells', () => {
 		it('can handle a 3x3 table, splitting a cell spanning over rows', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td', { rowspan: '2' }], ['td']],
-						['tr', ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td', { rowspan: '2' }], ['td']],
+					['tr', ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
-			const mutateGridModel = (gridModel) =>
-				splitCellIntoRows(gridModel, gridModel.getCellAtCoordinates(1, 1));
+			const mutateGridModel = (gridModel) => splitCellIntoRows(gridModel, gridModel.getCellAtCoordinates(1, 1));
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 
 		it('can handle a 3x3 table, splitting a cell spanning over columns', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td', { colspan: '2' }]],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td', { colspan: '2' }]],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
-			const mutateGridModel = (gridModel) =>
-				splitCellIntoColumns(gridModel, gridModel.getCellAtCoordinates(1, 1));
+			const mutateGridModel = (gridModel) => splitCellIntoColumns(gridModel, gridModel.getCellAtCoordinates(1, 1));
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options, mutateGridModel);
 		});
 	});
 
-	describe('Tables not conforming to settings (useThead, useTbody, useTh, useBorders)', () => {
+	describe('Tables not conforming to settings (useThead, useTbody, useTh, useBorders, shouldCreateColumnSpecificationNodes)', () => {
 		it('can transform a table based on thead, tbody, tfoot with 1 header row to a table based on rows only', () => {
-			const jsonIn = ['table',
-					['thead',
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tfoot',
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
-
-			const jsonOut = ['table', { border: '0' },
-					['tr', ['th'], ['th'], ['th'], ['th']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
+			const jsonIn = [
+				'table',
+				[
+					'thead',
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				],
+				[
+					'tbody',
 					['tr', ['td'], ['td'], ['td'], ['td']],
 					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+				],
+				[
+					'tfoot',
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
+
+			const jsonOut = [
+				'table', { border: '0' },
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
 			const options = {
-					useThead: false,
-					useTbody: false,
-					useTh: true
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: false,
+				useTbody: false,
+				useTh: true
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can transform a table based on rows to a table based on tbody', () => {
-			const jsonIn = ['table',
+			const jsonIn = [
+				'table',
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
 					['tr', ['td'], ['td'], ['td'], ['td']],
 					['tr', ['td'], ['td'], ['td'], ['td']],
 					['tr', ['td'], ['td'], ['td'], ['td']],
 					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
-
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can transform a table based on rows to a table based on rows', () => {
-			const jsonIn = ['table',
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonIn = [
+				'table',
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
-			const jsonOut = ['table', { border: '0' },
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: false,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: false,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can transform a table based on rows with 1 header row to a table based on rows with a header defined by thead', () => {
-			const jsonIn = ['table',
-					['tr', ['th'], ['th'], ['th'], ['th']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonIn = [
+				'table',
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
-			const jsonOut = ['table', { border: '0' },
-					['thead',
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'thead',
 					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+				],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: false,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: false,
+				useTh: false
+			};
+
+			transformTable(jsonIn, jsonOut, options);
+		});
+
+		it('can transform a table without cols to one with cols', () => {
+			const jsonIn = [
+				'table',
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const jsonOut = [
+				'table',
+				['col'],
+				['col'],
+				['col'],
+				['col'],
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const options = {
+				shouldCreateColumnSpecificationNodes: true,
+				useThead: false,
+				useTbody: false,
+				useTh: true,
+				useBorders: false
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can transform a table based on rows with 1 header row to a table based on rows with a header defined by both thead and th', () => {
-			const jsonIn = ['table',
-					['tr', ['th'], ['th'], ['th'], ['th']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonIn = [
+				'table',
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
-			const jsonOut = ['table', { border: '0' },
-					['thead',
-						['tr', ['th'], ['th'], ['th'], ['th']]
-					],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'thead',
+					['tr', ['th'], ['th'], ['th'], ['th']]
+				],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: false,
-					useTh: true
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: false,
+				useTh: true
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can transform a table based on rows with 1 header row to a table based on tbody and a header defined by thead', () => {
-			const jsonIn = ['table',
-					['tr', ['th'], ['th'], ['th'], ['th']],
+			const jsonIn = [
+				'table',
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'thead',
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				],
+				[
+					'tbody',
 					['tr', ['td'], ['td'], ['td'], ['td']],
 					['tr', ['td'], ['td'], ['td'], ['td']],
 					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
-
-			const jsonOut = ['table', { border: '0' },
-					['thead',
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: false
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can transform a table based on rows with 1 header row to a table based on tbody and a header defined by both thead and th', () => {
-			const jsonIn = ['table',
-					['tr', ['th'], ['th'], ['th'], ['th']],
+			const jsonIn = [
+				'table',
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'thead',
+					['tr', ['th'], ['th'], ['th'], ['th']]
+				],
+				[
+					'tbody',
 					['tr', ['td'], ['td'], ['td'], ['td']],
 					['tr', ['td'], ['td'], ['td'], ['td']],
 					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
-
-			const jsonOut = ['table', { border: '0' },
-					['thead',
-						['tr', ['th'], ['th'], ['th'], ['th']]
-					],
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: true
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: true
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can transform a table based on multiple tbody elements', () => {
-			const jsonIn = ['table',
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					],
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonIn = [
+				'table',
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				],
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
-			const jsonOut = ['table', { border: '0' },
-					['tbody',
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']],
-						['tr', ['td'], ['td'], ['td'], ['td']]
-					]
-				];
+			const jsonOut = [
+				'table', { border: '0' },
+				[
+					'tbody',
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']],
+					['tr', ['td'], ['td'], ['td'], ['td']]
+				]
+			];
 
 			const options = {
-					useThead: true,
-					useTbody: true,
-					useTh: true
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useThead: true,
+				useTbody: true,
+				useTh: true
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});
 
 		it('can turn borders off', () => {
-			const jsonIn = ['table',
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonIn = [
+				'table',
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
-			const jsonOut = ['table',
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']],
-					['tr', ['td'], ['td'], ['td'], ['td']]
-				];
+			const jsonOut = [
+				'table',
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
 
 			const options = {
-					useTh: true,
-					useBorders: false
-				};
+				shouldCreateColumnSpecificationNodes: false,
+				useTh: true,
+				useBorders: false
+			};
 
 			transformTable(jsonIn, jsonOut, options);
 		});


### PR DESCRIPTION
# Description

This pull request includes functionality for <col> elements. The current implementation does not insert <col> elements by default for new tables, therefore customizing of those elements is not possible. To enable support, a new option `shouldCreateColumnSpecificationNodes` is introduced. If set to true, `<col>` elements will be created by default in the XML-DOM (if the schema supports this).

Furthermore, the attributes `align` and `valign` are allowed on `<col>` elements. Although this attributes are obsolete according to [HTML5](https://www.w3.org/TR/2012/WD-html-markup-20120329/col.html), align may be allowed according to XHTML table models. 

For visualization, I rely on output classes (for my use case only `align` is relevant)

configureSxModule.js:
```javascript
var availableAligns = ["center", "right", "left", "justify"];
availableAligns.forEach(align => {
    // add according class to cols which are aligned and have no align on itself
    const alignXPath = `let $current := self::td[not(@align)] return $current/ancestor::table[1]/col[position() = count($current/preceding-sibling::td) + 1 and @align="${align}"]`;
    configureProperties(sxModule, alignXPath, {
        outputClass: "table-cell-" + align
    });
});
```
The align only applies to standard cells (`<td>`), although it may be simple to change the xpath expression.

And the according css:
```css
[cv-output-class="table-cell-center"] {
    text-align: center;
}

[cv-output-class="table-cell-left"] {
    text-align: left;
}

[cv-output-class="table-cell-right"] {
    text-align: right;
}

[cv-output-class="table-cell-justify"] {
    text-align: justify;
}
```

The code follows the official API according to [configureAsTableElements](http://documentation.fontoxml.com/editor/latest/configure-a-custom-table-definition-12425222.html#id-..Configureacustomtabledefinitionv7.1.0v7.3.0-Configuringthetabledefinition).

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Unfortunately, the provided test pipeline is not accessible without granted access. The code has been tested in our customer implementation via manuell tests.

**Test Configuration**:
* SDK: 7.3.2

You may take a look at https://bitbucket.org/liones/fontoxml-app-werkml-e-spirit-editor for an example.

# Checklist:

- [ ] My code follows the style guidelines of this project (no coding conventions provided).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] XPath Expression have been optimized for performance