### PR TITLE
Keep "align" and "valign" Attributes on Column Definition Nodes

### DIFF
--- a/src/table-definition/XhtmlTableDefinition.js
+++ b/src/table-definition/XhtmlTableDefinition.js
@@ -163,6 +163,11 @@ define([
 				getSpecificationValueStrategies.createGetValueAsBooleanStrategy('rowSeparator', './ancestor::' + table + '[1]/@border = "1"')
 			] : []),
 
+			getColumnSpecificationStrategies: shouldCreateColumnSpecificationNodes ? [
+				getSpecificationValueStrategies.createGetValueAsStringStrategy('horizontalAlignment', './@align'),
+				getSpecificationValueStrategies.createGetValueAsStringStrategy('verticalAlignment', './@valign')
+			] : [],
+
 			// Set attributes
 			setTableNodeAttributeStrategies: useBorders ? [
 				setAttributeStrategies.createBooleanValueAsAttributeStrategy('border', 'borders', null, '1', '0')
@@ -174,7 +179,12 @@ define([
 				setAttributeStrategies.createStringValueAsAttributeStrategy('char', 'characterAlignment'),
 				setAttributeStrategies.createStringValueAsAttributeStrategy('align', 'horizontalAlignment'),
 				setAttributeStrategies.createStringValueAsAttributeStrategy('valign', 'verticalAlignment')
-			]
+			],
+
+			setColumnSpecificationNodeAttributeStrategies: shouldCreateColumnSpecificationNodes ? [
+				setAttributeStrategies.createStringValueAsAttributeStrategy('align', 'horizontalAlignment'),
+				setAttributeStrategies.createStringValueAsAttributeStrategy('valign', 'verticalAlignment')
+			] : []
 		};
 
 		TableDefinition.call(this, properties);

--- a/test/specs/XhtmlRoundtrip.tests.js
+++ b/test/specs/XhtmlRoundtrip.tests.js
@@ -3104,4 +3104,154 @@ describe('XHTML tables: XML to XML roundtrip', () => {
 			transformTable(jsonIn, jsonOut, options);
 		});
 	});
+
+	describe('Keeps previously set @align and @valign attributes intact', () => {
+		it('can add a row to a table having col elements with @align and @valign attributes', () => {
+			const jsonIn = [
+				'table',
+				['col', { align: 'center', valign: 'middle' }],
+				['col', { align: 'center', valign: 'middle' }],
+				['col', { align: 'center', valign: 'middle' }],
+				['col', { align: 'center', valign: 'middle' }],
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const mutateGridModel = (gridModel) => gridModel.insertRow(2, false);
+
+			const jsonOut = [
+				'table', { border: '0' },
+				['col', { align: 'center', valign: 'middle' }],
+				['col', { align: 'center', valign: 'middle' }],
+				['col', { align: 'center', valign: 'middle' }],
+				['col', { align: 'center', valign: 'middle' }],
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const options = {
+				shouldCreateColumnSpecificationNodes: true,
+				useThead: false,
+				useTbody: false,
+				useTh: true
+			};
+
+			transformTable(jsonIn, jsonOut, options, mutateGridModel);
+		});
+
+		it('can add a row to a table having col elements with each having a different configuration of @align and @valign attributes', () => {
+			const jsonIn = [
+				'table',
+				['col', { align: 'center' }],
+				['col', { valign: 'middle' }],
+				['col', { align: 'left', valign: 'top' }],
+				['col'],
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const mutateGridModel = (gridModel) => gridModel.insertRow(2, false);
+
+			const jsonOut = [
+				'table', { border: '0' },
+				['col', { align: 'center' }],
+				['col', { valign: 'middle' }],
+				['col', { align: 'left', valign: 'top' }],
+				['col'],
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const options = {
+				shouldCreateColumnSpecificationNodes: true,
+				useThead: false,
+				useTbody: false,
+				useTh: true
+			};
+
+			transformTable(jsonIn, jsonOut, options, mutateGridModel);
+		});
+
+		it('does not add @align or @valign attributes on a table starting without col elements', () => {
+			const jsonIn = [
+				'table',
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const mutateGridModel = (gridModel) => gridModel.insertRow(2, false);
+
+			const jsonOut = [
+				'table', { border: '0' },
+				['col'],
+				['col'],
+				['col'],
+				['col'],
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const options = {
+				shouldCreateColumnSpecificationNodes: true,
+				useThead: false,
+				useTbody: false,
+				useTh: true
+			};
+
+			transformTable(jsonIn, jsonOut, options, mutateGridModel);
+		});
+
+		it('does not add @align or @valign attributes on a table starting with "empty" col elements', () => {
+			const jsonIn = [
+				'table',
+				['col'],
+				['col'],
+				['col'],
+				['col'],
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const mutateGridModel = (gridModel) => gridModel.insertRow(2, false);
+
+			const jsonOut = [
+				'table', { border: '0' },
+				['col'],
+				['col'],
+				['col'],
+				['col'],
+				['tr', ['th'], ['th'], ['th'], ['th']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']],
+				['tr', ['td'], ['td'], ['td'], ['td']]
+			];
+
+			const options = {
+				shouldCreateColumnSpecificationNodes: true,
+				useThead: false,
+				useTbody: false,
+				useTh: true
+			};
+
+			transformTable(jsonIn, jsonOut, options, mutateGridModel);
+		});
+	});
 });


### PR DESCRIPTION
# Description

This pull request includes functionality for keeping attributes on `<col>`  elements which were introduced in #2 .
Currently, set attributes on `<col>` elements via `xhtml-set-col-horizontal-alignment-left` (or similar operations) are removed if the table structure is modified.
A structure modification occurs on inserting or removing a row or column for example.
To keep the attributes, `getColumnSpecificationStrategies` and `setColumnSpecificationNodeAttributeStrategies` have been included in the Table Definition Properties according to the [Documentation](https://documentation.fontoxml.com/api/latest/tabledefinitionproperties-21332683.html). The definitions are only present, if the option `shouldCreateColumnSpecificationNodes` has been set to `true`.

# How Has This Been Tested?

Despite a self test, no automatic tests are included with this pull request (access to the test docker image fontoxmltoolsinternal.azurecr.io/build-tools/fontoxml-pipeline-test-build:latest, to the run the tests locally, is forbidden).

**Test Configuration**:
* SDK: 7.5.3 (unfortunately not up to date yet :/)

# Checklist:

- [ ] My code follows the style guidelines of this project (no coding conventions provided).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] XPath Expression have been optimized for performance